### PR TITLE
TUR-23776: Do not use precompiled headers if building with ccache

### DIFF
--- a/source/glbinding/CMakeLists.txt
+++ b/source/glbinding/CMakeLists.txt
@@ -309,7 +309,7 @@ target_link_libraries(${target}
 # Precompiled Header Configuration
 #
 
-if (MSVC_IDE)
+if (MSVC_IDE AND NOT NTOP_CCACHE)
     # on msvc use private (non-api) per file precompiled headers on those grouped sources
 
     set_source_files_properties(${source_path}/Binding_pch.cpp PROPERTIES COMPILE_FLAGS /Yc"Binding_pch.h")


### PR DESCRIPTION
### Summary
[TUR-23776](https://ntopology.atlassian.net/browse/TUR-23776) required by [this turbo PR](https://github.com/nTopology/turbo/pull/14633)

[TUR-23776]: https://ntopology.atlassian.net/browse/TUR-23776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ